### PR TITLE
Note requirement of JavaScript runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or install it yourself as:
 $ gem install jekyll-coffeescript
 ```
 
-**Note: `jekyll-coffeescript` requires Ruby 1.9.3 or greater.**
+**Notes: `jekyll-coffeescript` requires Ruby 1.9.3 or greater. Additionally, the dependency on `execjs` means you must also have a [valid JavaScript runtime](https://github.com/sstephenson/execjs#execjs) available to your project**
 
 ## Usage
 


### PR DESCRIPTION
`jekyll-coffeescript` requires a valid JavaScript runtime due to its dependency on ExecJS, but this is undocumented. jekyll/jekyll#2327 makes me think that it probably should be!
