### PR TITLE
In Converters::CoffeeScript#matches, never return anything but true or false

### DIFF
--- a/lib/jekyll/converters/coffeescript.rb
+++ b/lib/jekyll/converters/coffeescript.rb
@@ -5,7 +5,7 @@ module Jekyll
       priority :low
 
       def matches(ext)
-        ext =~ /^\.coffee$/i
+        !!(ext =~ /^\.coffee$/i)
       end
 
       def output_ext(ext)


### PR DESCRIPTION
Previously, it was returning the index where the string was first seen.
Regexp is silly.
