### PR TITLE
Load converter when used.

### DIFF
--- a/lib/jekyll-coffeescript.rb
+++ b/lib/jekyll-coffeescript.rb
@@ -1,5 +1,4 @@
 require "jekyll"
-require "coffee-script"
 require "jekyll-coffeescript/version"
 require "jekyll/converters/coffeescript"
 

--- a/lib/jekyll/converters/coffeescript.rb
+++ b/lib/jekyll/converters/coffeescript.rb
@@ -13,6 +13,7 @@ module Jekyll
       end
 
       def convert(content)
+        require "coffee-script"
         ::CoffeeScript.compile(content)
       end
     end

--- a/lib/jekyll/converters/coffeescript.rb
+++ b/lib/jekyll/converters/coffeescript.rb
@@ -4,6 +4,11 @@ module Jekyll
       safe true
       priority :low
 
+      def setup
+        require "coffee-script"
+        @setup = true
+      end
+
       def matches(ext)
         ext.downcase == ".coffee"
       end
@@ -13,7 +18,7 @@ module Jekyll
       end
 
       def convert(content)
-        require "coffee-script"
+        setup unless @setup
         ::CoffeeScript.compile(content)
       end
     end


### PR DESCRIPTION
cross reference: jekyll/jekyll#2327

Make it so that you can use Jekyll 2.x without a JavaScript runtime, as long as you don't need to compile CoffeeScript.

Sample error when you try to do that:
```
$ jekyll b
Configuration file: /home/guest1212/Workspaces/site/_config.yml
            Source: /home/guest1212/Workspaces/site
       Destination: /home/guest1212/Workspaces/site/_site
      Generating... 
  Conversion error: Jekyll::Converters::CoffeeScript encountered an error while converting 'test.coffee':
                    Could not find a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes.
jekyll 2.5.3 | Error:  Could not find a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes.
```