### PR TITLE
Add Jekyll 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
+- 2.2
 - 2.1.0
 - 2.0.0
 - 1.9.3
 script: script/cibuild
+
 notifications:
   irc:
     on_success: change
@@ -17,7 +19,22 @@ notifications:
   email:
     on_success: never
     on_failure: never
+
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      env: JEKYLL_VERSION=3.0.0
+    - env: JEKYLL_VERSION=2.0
+      rvm: 2.1
+    - rvm: 2.2
+      env: JEKYLL_VERSION=2.0
+
 env:
+  matrix:
+#    - ""
+    - JEKYLL_VERSION=2.0
+    - JEKYLL_VERSION=3.0.0
+
   global:
   - secure: c3L8fa91PLodwiKuNevq5/Froh2h3PPG22NMavTBnu2YLBeSnPHMc2yasEAbH9hBKkw0LqMCdqF13uaQWdulI0Ez5ylUvg2tUi1KPRjQkSBZgZZVurQkCwNvhbttRYLgwDbuDBLguVFkl1q4/eFTCcTPW/20p0tsCWKpddmjO0I=
   - secure: H4CFVnFXtDcm6R3d6038RbYA9uV0yJ2fHb7GDwQmGJWIK8zB5FEzOykGT+C6/7hrVXy5fNK4fn+Zrt/WPRmxiMSirLWiMt+X7Cu+stFdMkdAwQq32/rFCSzbTszoCs+pCFGYEW2Iyj9rs2tgkxy8hKvG7ypDZ4keSKyxm8kBAMA=

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,6 @@
 source 'https://rubygems.org'
 gemspec
+
+if ENV["JEKYLL_VERSION"]
+  gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}"
+end

--- a/jekyll-coffeescript.gemspec
+++ b/jekyll-coffeescript.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "coffee-script", "~> 2.2"
 
-  spec.add_development_dependency "jekyll", "~> 2.0"
+  spec.add_development_dependency "jekyll", ">= 2.0", ">= 3.0"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
This PR is created in order to address the need as outlined (jekyll/jekyll/issues/3945) to verify gems are compatible with Jekyll 3.

Added Ruby 2.2 in the build matrix and changed Jekyll dependency to <= 2.0. Not sure what happened with the other PR, so I figured I would create my own.