### PR TITLE
Inherit Jekyll's rubocop config for consistency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,15 @@
+inherit_gem:
+  jekyll: .rubocop.yml
+
+Metrics/LineLength:
+  Exclude:
+    - spec/**/*
+    - jekyll-coffeescript.gemspec
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+
+Style/IndentHeredoc:
+  Exclude:
+    - spec/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 gemspec
 
 if ENV["JEKYLL_VERSION"]

--- a/jekyll-coffeescript.gemspec
+++ b/jekyll-coffeescript.gemspec
@@ -1,24 +1,25 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'jekyll-coffeescript/version'
+require "jekyll-coffeescript/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-coffeescript"
   spec.version       = Jekyll::Coffeescript::VERSION
   spec.authors       = ["Parker Moore"]
   spec.email         = ["parkrmoore@gmail.com"]
-  spec.summary       = %q{A CoffeeScript converter for Jekyll.}
+  spec.summary       = "A CoffeeScript converter for Jekyll."
   spec.homepage      = "https://github.com/jekyll/jekyll-coffeescript"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($/).grep(%r{(lib/)})
+  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep(%r!(lib/)!)
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "coffee-script-source", "~> 1.11.1"
   spec.add_runtime_dependency "coffee-script", "~> 2.2"
 
-  spec.add_development_dependency "jekyll", ENV['JEKYLL_VERSION'] ? "~> #{ENV['JEKYLL_VERSION']}" : ">= 2.0"
+  spec.add_development_dependency "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : ">= 2.0"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/jekyll-coffeescript/version.rb
+++ b/lib/jekyll-coffeescript/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Coffeescript
-    VERSION = "1.0.2"
+    VERSION = "1.0.2".freeze
   end
 end

--- a/lib/jekyll/converters/coffeescript.rb
+++ b/lib/jekyll/converters/coffeescript.rb
@@ -10,10 +10,10 @@ module Jekyll
       end
 
       def matches(ext)
-        ext.downcase == ".coffee"
+        ext.casecmp(".coffee").zero?
       end
 
-      def output_ext(ext)
+      def output_ext(_ext)
         ".js"
       end
 

--- a/spec/coffeescript_spec.rb
+++ b/spec/coffeescript_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe(Jekyll::Converters::CoffeeScript) do
   let(:configuration) { Jekyll::Configuration::DEFAULTS }
@@ -60,5 +60,4 @@ JS
       expect(converter.convert(coffeescript_content)).to eql(js_content)
     end
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,8 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
-require 'jekyll'
-require 'jekyll-coffeescript'
+require "jekyll"
+require "jekyll-coffeescript"
 
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
@@ -16,5 +16,5 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = 'random'
+  config.order = "random"
 end


### PR DESCRIPTION
This PR is the result of adding `inherit_gem:\n jekyll: .rubocop.yml` to `.rubocop.yml` and running `rubocop -a` so that this project follows Jekyll core's coding styles for consistency like other core plugins. This way, as Jekyll's Ruby style changes, so too will this project's.