### PR TITLE
Test against Ruby 2.1 to 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 sudo: false
 language: ruby
 rvm:
-- 2.0
-- 2.1
-- 2.2
+  - 2.4
+  - 2.3
+  - 2.2
+  - 2.1
 env:
   matrix:
     - JEKYLL_VERSION=2.5


### PR DESCRIPTION
Jekyll requires at least Ruby 2.1
GitHub Pages is running Ruby 2.4