### PR TITLE
Re-introduce Ruby 2.3 support and test Jekyll 3.7+

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,4 +6,4 @@ inherit_gem:
   rubocop-jekyll: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.6
+  - &latest_ruby 2.6
   - 2.4
+  - 2.3
 env:
   matrix:
-    - JEKYLL_VERSION=3.7
+    - JEKYLL_VERSION="~> 3.8"
 matrix:
   include:
-    rvm: 2.6
-    script: script/fmt
+    - rvm: *latest_ruby
+      env: JEKYLL_VERSION="~> 3.7.4"
+    - rvm: *latest_ruby
+      env: JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
+    - rvm: *latest_ruby
+      script: script/fmt
 branches:
   only:
     - master

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@
 
 source "https://rubygems.org"
 gemspec
+
+gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]

--- a/jekyll-coffeescript.gemspec
+++ b/jekyll-coffeescript.gemspec
@@ -16,13 +16,13 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep(%r!(lib/)!)
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_runtime_dependency "coffee-script", "~> 2.2"
   spec.add_runtime_dependency "coffee-script-source", "~> 1.12"
+  spec.add_runtime_dependency "jekyll", ">= 2.0"
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : ">= 3.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rubocop-jekyll", "~> 0.5"


### PR DESCRIPTION
Since we're not using Ruby 2.4 specific syntax, we can relax Ruby version constraint to the minimum testable version across the ecosystem: Ruby 2.3

Other changes:
  - **list `jekyll` as a `runtime_dependency`**
  - Test with Jekyll 4.0 pre-release

**Note:** Based on https://github.com/jekyll/jekyll-coffeescript/compare/v1.1.1...v1.2.0, the only changes eligible for a major version bump was dropping support for `< Ruby 2.4` and `< Jekyll 3.0`. Since, no other significant change was made to the `lib` files, I've reverted the change to drop `< Jekyll 3.0` support.