### PR TITLE
Require Ruby 2.4 or greater

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,4 +6,4 @@ inherit_gem:
   rubocop-jekyll: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: ruby
 cache: bundler
 rvm:
   - &latest_ruby 2.6
+  - 2.5
   - 2.4
-  - 2.3
 env:
   matrix:
     - JEKYLL_VERSION="~> 3.8"
@@ -12,7 +12,7 @@ matrix:
     - rvm: *latest_ruby
       env: JEKYLL_VERSION="~> 3.7.4"
     - rvm: *latest_ruby
-      env: JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
+      env: JEKYLL_VERSION="~> 4.0"
     - rvm: *latest_ruby
       script: script/fmt
 branches:

--- a/jekyll-coffeescript.gemspec
+++ b/jekyll-coffeescript.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep(%r!(lib/)!)
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.4.0"
 
   spec.add_runtime_dependency "coffee-script", "~> 2.2"
   spec.add_runtime_dependency "coffee-script-source", "~> 1.12"


### PR DESCRIPTION
Ruby 2.3 is no longer supported by the Ruby core team and Jekyll 4 no longer supports it either.